### PR TITLE
Add JNA dependency to unit test for Mac M1 machine.

### DIFF
--- a/Chapter06/microservices/product-service/build.gradle
+++ b/Chapter06/microservices/product-service/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:mongodb'
+
+    // If you're using Mac M1 chip machine, you should add this dependency, otherwise, unit test will fail.
+    testImplementation 'net.java.dev.jna:jna-platform:5.8.0'
 }
 
 test {

--- a/Chapter06/microservices/recommendation-service/build.gradle
+++ b/Chapter06/microservices/recommendation-service/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:mongodb'
+
+    // If you're using Mac M1 chip machine, you should add this dependency, otherwise, unit test will fail.
+    testImplementation 'net.java.dev.jna:jna-platform:5.8.0'
 }
 
 test {

--- a/Chapter06/microservices/review-service/build.gradle
+++ b/Chapter06/microservices/review-service/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:mysql'
+
+    // If you're using Mac M1 chip machine, you should add this dependency, otherwise, unit test will fail.
+    testImplementation 'net.java.dev.jna:jna-platform:5.8.0'
 }
 
 test {


### PR DESCRIPTION
Without the dependency, unit test will fail on Mac M1 chip machine.